### PR TITLE
Bug fixes for initial release

### DIFF
--- a/seamm_installer/conda.py
+++ b/seamm_installer/conda.py
@@ -139,30 +139,26 @@ class Conda(object):
 
         # Find the root path for the environment
         # Typically the base environment is e.g. ~/opt/miniconda3 and all other
-        # environments are in ~/opt/miniconda3/envs/ We want the path for the base
-        # environment.
+        # environments are in ~/opt/miniconda3/envs/ (~/opt/anaconda3).
+        # We want the path for the base environment.
+        #
+        # In some installations there are more than one base environment! So
+        # pick the one that looks like 'anacondaX' or 'minicondaX'.
+        # As a last resort, just pick one.
         self.logger.debug("Finding the conda root path")
-        root = None
+        roots = set()
         for env in self._data["envs"]:
             path = Path(env)
             self.logger.debug(f"    environment path {path}")
             if path.parent.name == "envs":
-                if root is None:
-                    root = path.parent.parent
-                    self.logger.debug(f"    root <-- {root}")
-                elif root != path.parent.parent:
-                    raise RuntimeError(
-                        f"Problem finding the root of the Conda installation: {env} is "
-                        f"not a subdirectory of {root}."
-                    )
+                roots.add(path.parent.parent)
             else:
-                if root is None:
-                    root = path
-                    self.logger.debug(f"    root <-- {root}")
-                else:
-                    raise RuntimeError(
-                        f"Found two roots for the Conda installation: {env} and {root}."
-                    )
+                roots.add(path)
+        for root in roots:
+            name = root.name
+            if "miniconda" in name or "anaconda" in name:
+                break
+
         self.root_path = root
 
         tmp = "\n\t".join(self.environments)

--- a/seamm_installer/data/seamm.ini
+++ b/seamm_installer/data/seamm.ini
@@ -1,0 +1,80 @@
+# Configuration options for SEAMM.
+#
+# The options in this file override any defaults in SEAMM
+# and its plug-ins; however, command-line arguments will
+# in turn override the values here.
+#
+# The keys should have dashes '-' separating words. In either case,
+# the command line options is '--<key with dashes>' and the variable
+# name inside SEAMM is '<key with underscores>', e.g. 'log-level' in
+# this file corresponds to the command line option '--log-level'
+# and the variable in SEAMM 'log_level'.
+#
+# The file is broken into sections, with a name in square brackets,
+# like [lammps-step]. Within each section there can be a series of
+# option = value statements. '#' introduces comment lines. The
+# section names and variables should be in lower case except for
+# the [DEFAULT] and [SEAMM] sections which are special.
+#
+# [DEFAULT] provides default values for any other section. If an
+# option is requested for a section, but does not exist in that
+# section, the option is looked for in the [DEFAULT] section. If it
+# exists there, the corresponding value is used.
+#
+# The [SEAMM] section contains options for the SEAMM environment
+# itself. On the command line these come before any options for
+# plug-ins, which follow the name of the plug-in. The plug-in name is
+# also the section in this file for that plug-in.
+#
+# All other sections are for the plug-ins, and generally have the form
+# [xxxxx-step], in lowercase.
+#
+# Finally, options can refer to options in the same or other sections
+# with a syntax like ${section:option}. If the section is omitted,
+# the current section and [DEFAULT] are searched, in that
+# order. Otherwise the given section and [DEFAULT] are searched.
+
+[DEFAULT]
+# Default values for options in any section.
+
+[SEAMM]
+# Options for the SEAMM infrastructure.
+
+# The root directory
+# root = ~/SEAMM
+
+# The location of the datastore
+# datastore = ${root}/Jobs
+
+# The config file for dashboards.
+# dashboards = ${root}/dashboards.ini
+
+######################################
+# Options when running jobs manually #
+######################################
+
+# The default project
+# project = default
+
+# Running parallel
+#   none, mpi, openmp, or any
+# parallelism = any
+
+# The maximum number of cores to use in any step:
+# max-cores = 2
+
+# The maximum amount of memory to use in any step
+# Use kB, MB, GB (1k = 1000) or kiB, MiB, GiB (1k = 1024)
+# Note that node all codes honor this!
+# 'available' requests using all the available memory
+# while 'all' requests using all the physical memory.
+# The default is 'available'.
+# max-memory = available
+
+######################################
+# Options for the Dashboard          #
+######################################
+secret-key = 
+debug = False
+
+"""

--- a/seamm_installer/data/seamm.ini
+++ b/seamm_installer/data/seamm.ini
@@ -77,4 +77,3 @@
 secret-key = 
 debug = False
 
-"""


### PR DESCRIPTION
closes issue #10 where the SEAMM section of the configuration file `seamm.ini` is not filled out. The installer adds a commented out section and also sets the `secret-key` for the Dashboard to a random string.

closes issue #11 by handling multiple conda root directories in a heuristic fashion, looking for bases that end in `minicondaX` or `anacondaX` where X is a number like 3. In the worst case it just picks one (and hopes!)