### PR TITLE
add check and message to seamm-installer run without proper arguments

### DIFF
--- a/seamm_installer/__main__.py
+++ b/seamm_installer/__main__.py
@@ -96,7 +96,7 @@ def run():
         from .gui import GUI
 
         gui = GUI(logger=my.logger)
-        
+
         # enter the event loop
         gui.event_loop()
 

--- a/seamm_installer/__main__.py
+++ b/seamm_installer/__main__.py
@@ -72,7 +72,14 @@ def run():
 
     # Parse the command-line arguments and call the requested function
     my.options = parser.parse_args()
-    sys.exit(my.options.func())
+    try:
+        sys.exit(my.options.func())
+    except AttributeError:
+        print(f"Missing arguments to seamm-installer {' '.join(sys.argv[1:])}")
+        # Append help so help will be printed
+        sys.argv.append("--help")
+        # re-run
+        run()
 
 
 if __name__ == "__main__":

--- a/seamm_installer/__main__.py
+++ b/seamm_installer/__main__.py
@@ -96,6 +96,9 @@ def run():
         from .gui import GUI
 
         gui = GUI(logger=my.logger)
+        
+        # enter the event loop
+        gui.event_loop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I noticed that when I ran the `seamm-installer` incorrectly, I wasn't getting a helpful message. 

Example of behavior:
```
seamm-installer apps
```

Resulted in:
```
File "/root/miniconda3/envs/seamm/bin/seamm-installer", line 10, in <module>
    sys.exit(run())
  File "/root/miniconda3/envs/seamm/lib/python3.9/site-packages/seamm_installer/__main__.py", line 76, in run
    sys.exit(my.options.func())
AttributeError: 'Namespace' object has no attribute 'func'
```

I added a `try except` block which prints a message about incorrect usage, then appends `--help` to the arguments lists and reruns seamm-installer. This way, the `--help` message for the installer or other arguments will be printed.

This changes the behavior to:

```
seamm-installer apps
Missing arguments to seamm-installer apps
usage: seamm-installer apps [-h] {create,delete,show,update} ...

positional arguments:
  {create,delete,show,update}

optional arguments:
  -h, --help            show this help message and exit
```


