### PR TITLE
Bugfix: simplejson caused crash

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2025.8.22: Bugfix: simplejson caused crash
+    * If installed by one of the packages, simplejson caused the installer to crash
+      because of an incompatibility between simplejson and the standard Python JSON
+      package.
+    * Improved feedback about progress when install and updating from the GUI.
+
 2025.7.7: Bugfix: Ensure creation of ~/SEAMM directory
 
 2025.6.21: Bugfix: error in path to Conda environments.

--- a/seamm_installer/conda.py
+++ b/seamm_installer/conda.py
@@ -623,9 +623,9 @@ class Conda(object):
             command += " "
             command += " ".join(package)
 
-        self._execute(command)
+        self._execute(command, progress=progress, update=update)
 
-    def update_environment(self, environment_file, name=None):
+    def update_environment(self, environment_file, name=None, update=None):
         """Update a Conda environment.
 
         Parameters
@@ -649,7 +649,7 @@ class Conda(object):
         print(f"command = {command}")
         self.logger.debug(f"command = {command}")
         try:
-            self._execute(command)
+            self._execute(command, update=update)
         except subprocess.CalledProcessError as e:
             self.logger.warning(f"Calling conda, returncode = {e.returncode}")
             self.logger.warning(f"Output:\n\n{e.output}\n\n")
@@ -705,6 +705,7 @@ class Conda(object):
                             n = 0
                         sys.stdout.flush()
                     else:
+                        print("Conda execute calling update")
                         update()
             else:
                 if output != "":

--- a/seamm_installer/gui.py
+++ b/seamm_installer/gui.py
@@ -670,13 +670,18 @@ class GUI(collections.abc.MutableMapping):
                 to_install.append(package)
         n = len(to_install)
 
-        self.progress_bar.configure(mode="indeterminate")
+        self.progress_bar.configure(mode="indeterminate", maximum=20, value=0)
         self.progress_text.configure(text=f"Installing/updating {n} packages")
         self.progress_dialog.deiconify()
         self.root.update()
-        self.progress_bar.start()
 
-        install_packages(to_install, update=update, gui_only=gui_only)
+        install_packages(
+            to_install,
+            update=update,
+            gui_only=gui_only,
+            progress=self._update_progress_step,
+            update_text=self._update_progress_text,
+        )
 
         # Fix the package list
         self._clear_selection()
@@ -691,8 +696,16 @@ class GUI(collections.abc.MutableMapping):
 
             install_development_environment()
 
-        self.progress_bar.stop()
+        # self.progress_bar.stop()
         self.progress_dialog.withdraw()
+
+    def _update_progress_step(self):
+        self.progress_bar.step()
+        self.root.update()
+
+    def _update_progress_text(self, text):
+        self.progress_text.configure(text=text)
+        self.root.update()
 
     def _uninstall(self, gui_only=False):
         "Uninstall selected packages."
@@ -725,18 +738,21 @@ class GUI(collections.abc.MutableMapping):
                 to_update.append(package)
         n = len(to_update)
 
-        self.progress_bar.configure(mode="indeterminate")
+        self.progress_bar.configure(mode="indeterminate", maximum=20, value=0)
         self.progress_text.configure(text=f"Updating {n} packages")
         self.progress_dialog.deiconify()
         self.root.update()
-        self.progress_bar.start()
 
-        update_packages(to_update, gui_only=gui_only)
+        update_packages(
+            to_update,
+            gui_only=gui_only,
+            progress=self._update_progress_step,
+            update_text=self._update_progress_text,
+        )
 
         self._clear_selection()
         self._refresh_cache()
 
-        self.progress_bar.stop()
         self.progress_dialog.withdraw()
 
         if my.development:

--- a/seamm_installer/install.py
+++ b/seamm_installer/install.py
@@ -100,12 +100,25 @@ def install():
         install_development_environment()
 
 
-def install_packages(to_install, update=False, third_party=False, gui_only=False):
+def install_packages(
+    to_install,
+    update=False,
+    third_party=False,
+    gui_only=False,
+    progress=None,
+    update_text=None,
+):
     """Install SEAMM components and plug-ins."""
     metadata = get_metadata()
 
+    if progress is not None:
+        progress()
+
     # Find all the packages
     packages = find_packages(progress=True)
+
+    if progress is not None:
+        progress()
 
     if to_install == "all":
         if third_party:
@@ -117,6 +130,9 @@ def install_packages(to_install, update=False, third_party=False, gui_only=False
 
     # Get the info about the installed packages
     info = my.conda.list(environment=my.environment)
+
+    if progress is not None:
+        progress()
 
     conda_packages = []
     pypi_packages = []
@@ -175,12 +191,15 @@ def install_packages(to_install, update=False, third_party=False, gui_only=False
     path = directory / f"{tstamp}_install.yml"
     path.write_text(env)
 
+    if progress is not None:
+        progress()
+
     # And do the update
     if update:
         print(f"Installing to and updating the Conda environment with {path.name}")
     else:
         print(f"Installing into the Conda environment with {path.name}")
-    my.conda.update_environment(path, name=my.environment)
+    my.conda.update_environment(path, name=my.environment, update=progress)
     print("done")
 
     # Write the export file
@@ -193,6 +212,8 @@ def install_packages(to_install, update=False, third_party=False, gui_only=False
 
     # Restart services and run custom installer
     for package in to_install:
+        if progress is not None:
+            progress()
         if not update and package in info:
             continue
 
@@ -211,6 +232,11 @@ def install_packages(to_install, update=False, third_party=False, gui_only=False
 
         # See if the package has an installer
         if not metadata["gui-only"] and not gui_only:
+            if progress is not None:
+                progress()
+            if update_text is not None:
+                print(f"Installing background codes for {package}")
+                update_text(f"Installing background codes for {package}")
             run_plugin_installer(package, "install")
 
 

--- a/seamm_installer/update.py
+++ b/seamm_installer/update.py
@@ -125,18 +125,27 @@ def update():
                 print(f"Restarted the {service_name} because it was updated.")
 
 
-def update_packages(to_update, gui_only=False):
+def update_packages(to_update, gui_only=False, progress=None, update_text=None):
     """Update SEAMM components and plug-ins."""
     metadata = get_metadata()
 
+    if progress is not None:
+        progress()
+
     # Find all the packages
     packages = find_packages(progress=True)
+
+    if progress is not None:
+        progress()
 
     if to_update == "all":
         to_update = [*packages.keys()]
 
     # Get the info about the installed packages
     info = my.conda.list(environment=my.environment)
+
+    if progress is not None:
+        progress()
 
     conda_packages = []
     pypi_packages = []
@@ -182,6 +191,9 @@ def update_packages(to_update, gui_only=False):
         conda_packages, pypi_packages, installed_packages=[*packages.keys()]
     )
 
+    if progress is not None:
+        progress()
+
     directory = my.root / "environments"
     directory.mkdir(exist_ok=True)
     tstamp = datetime.now().isoformat(timespec="seconds")
@@ -190,7 +202,7 @@ def update_packages(to_update, gui_only=False):
 
     # And do the update
     print(f"Updating the Conda environment with {path.name}")
-    my.conda.update_environment(path, name=my.environment)
+    my.conda.update_environment(path, name=my.environment, update=progress)
     print("done")
 
     # Write the export file
@@ -206,6 +218,11 @@ def update_packages(to_update, gui_only=False):
         for package in to_update:
             # Skip packages that aren't installed.
             if package in info:
+                if progress is not None:
+                    progress()
+                if update_text is not None:
+                    print(f"Updating background codes for {package}")
+                    update_text(f"Updating background codes for {package}")
                 run_plugin_installer(package, "update")
 
 

--- a/seamm_installer/util.py
+++ b/seamm_installer/util.py
@@ -33,7 +33,8 @@ class JSONEncoder(json.JSONEncoder):
 class JSONDecoder(json.JSONDecoder):
     """Class for handling the package versions in JSON."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
+        # kwargs because simplejson passes in encoding=.... causing crash
         super().__init__(object_hook=self.dict_to_object)
 
     def dict_to_object(self, d):
@@ -143,6 +144,11 @@ def find_packages(progress=True, update=None, update_cache=False, cache_valid=1)
         response = requests.get(url)
         record = response.json(cls=JSONDecoder)
     except Exception as e:
+        print(f"Error finding the package list from Zenodo: {str(e)}")
+        print("The text of the response from Zenodo is:")
+        print(80 * "-")
+        pprint.pprint(response.text)
+        print(80 * "-")
         raise RuntimeError(f"Error finding the package list from Zenodo: {str(e)}")
 
     # Find SEAMM_packages.json


### PR DESCRIPTION
* If installed by one of the packages, simplejson caused the installer to crash because of an incompatibility between simplejson and the standard Python JSON package.
* Improved feedback about progress when install and updating from the GUI.