### PR TITLE
Bugfix: clearer errors when the Zenodo package list can't be fetched

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 =======
 History
 =======
+2026.7.26 -- Bugfix: clearer errors when the Zenodo package list can't be fetched
+    * ``find_packages()`` now uses ``seamm_util.Zenodo.get_latest_public_record()``
+      instead of hand-rolled requests calls to the Zenodo API. This also fixes a
+      latent bug: the old error handling referenced the HTTP response even when
+      the request itself had failed before a response existed, which could raise
+      a confusing ``NameError`` instead of reporting the real problem reaching
+      Zenodo.
+
 2026.2.26 -- Internal: moving from pkg_resources to importlib.resources
 
 2025.8.22: Bugfix: simplejson caused crash

--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,12 @@ install: uninstall ## install the package to the active Python's site-packages
 
 uninstall: clean ## uninstall the package
 	pip uninstall --yes $(MODULE)
+
+.PHONY: update
+update: ## post-release: sync main and dev, reinstall, run checks, push dev
+	git checkout main
+	git pull
+	git checkout dev
+	git merge --ff-only main
+	$(MAKE) lint install test
+	git push

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -7,9 +7,12 @@ dependencies:
   # Base depends
   - python
   - pip
+  - alembic
+  - packaging
   - platformdirs
   - pmw
   - requests
+  - seamm-util
   - seamm-widgets
   - tabulate
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ packaging
 platformdirs
 pmw
 requests
+seamm-util
 seamm-widgets
 tabulate
 

--- a/seamm_installer/util.py
+++ b/seamm_installer/util.py
@@ -11,7 +11,7 @@ import shutil
 import subprocess
 
 from platformdirs import user_data_dir
-import requests
+from seamm_util import Zenodo
 
 from .conda import Conda
 from . import my
@@ -137,35 +137,18 @@ def find_packages(progress=True, update=None, update_cache=False, cache_valid=1)
     dict(str, str)
         A dictionary with information about the packages.
     """
-    url = "https://zenodo.org/api/records/7789854/versions/latest"
+    zenodo = Zenodo()
     try:
-        response = requests.get(url)
-        record = response.json(cls=JSONDecoder)
+        record = zenodo.get_latest_public_record(7789854)
     except Exception as e:
-        print(f"Error finding the package list from Zenodo: {str(e)}")
-        print("The text of the response from Zenodo is:")
-        print(80 * "-")
-        pprint.pprint(response.text)
-        print(80 * "-")
         raise RuntimeError(f"Error finding the package list from Zenodo: {str(e)}")
 
-    # Find SEAMM_packages.json
-    url = None
-    for data in record["files"]:
-        if data["key"] == "SEAMM_packages.json":
-            url = data["links"]["self"]
-            break
-    if url is None:
-        raise RuntimeError(
-            "Unable to get the package list from Zenodo. "
-            "There is no file 'SEAMM_packages.json'"
-        )
-
     try:
-        response = requests.get(url)
-        package_db = response.json(cls=JSONDecoder)
+        text = record.get_file("SEAMM_packages.json")
     except Exception as e:
         raise RuntimeError(f"Error getting the package list from Zenodo: {str(e)}")
+
+    package_db = json.loads(text, cls=JSONDecoder)
 
     my.package_metadata = package_db["metadata"] if "metadata" in package_db else []
 


### PR DESCRIPTION
* `find_packages()` now uses `seamm_util.Zenodo.get_latest_public_record()` instead of hand-rolled requests calls to the Zenodo API. This also fixes a latent bug: the old error handling referenced the HTTP response even when the request itself had failed before a response existed, which could raise a confusing `NameError` instead of reporting the real problem reaching Zenodo.
* Added `alembic`, `packaging`, and `seamm-util` to `devtools/conda-envs/test_env.yaml` (they were in `requirements.txt` but missing from the CI test environment spec).