### PR TITLE
Install and daemonize seamm_webui

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 =======
 History
 =======
+2026.8.10 -- Install and daemonize seamm_webui
+    * ``seamm-installer install seamm-webui`` creates a dedicated ``seamm-webui``
+      Conda environment (it shares little with the rest of the SEAMM stack) and
+      installs ``seamm_webui`` from PyPI into it.
+    * ``seamm-installer services create webui`` (alongside the existing
+      ``dashboard``/``jobserver`` services) sets up and starts it as a persistent
+      systemd/launchd daemon, with a new ``--webui-host`` option.
+
 2026.7.26 -- Bugfix: clearer errors when the Zenodo package list can't be fetched
     * ``find_packages()`` now uses ``seamm_util.Zenodo.get_latest_public_record()``
       instead of hand-rolled requests calls to the Zenodo API. This also fixes a

--- a/seamm_installer/install.py
+++ b/seamm_installer/install.py
@@ -4,11 +4,18 @@
 
 from datetime import datetime
 import platform
+import subprocess
+import tempfile
+from pathlib import Path
 
 from packaging.version import Version
 
 from . import datastore
-from .metadata import development_packages, development_packages_pip
+from .metadata import (
+    development_packages,
+    development_packages_pip,
+    standalone_packages,
+)
 from . import my
 from .util import (
     create_env,
@@ -92,12 +99,67 @@ def install():
             gui_only=my.options.gui_only,
         )
     else:
-        install_packages(
-            my.options.modules, update=my.options.update, gui_only=my.options.gui_only
-        )
+        # standalone_packages (currently just seamm-webui) aren't in the
+        # Zenodo-hosted package registry install_packages() reads from --
+        # not installed into the shared main environment, so they can't go
+        # through that generic per-package flow. Handle them directly here,
+        # then hand off anything else requested to install_packages() as
+        # usual.
+        modules = list(my.options.modules)
+        for package in standalone_packages:
+            if package in modules:
+                modules.remove(package)
+                install_seamm_webui(update=my.options.update)
+
+        if modules:
+            install_packages(
+                modules, update=my.options.update, gui_only=my.options.gui_only
+            )
 
     if my.development:
         install_development_environment()
+
+
+def install_seamm_webui(update=False):
+    """Create/update the dedicated `seamm-webui` Conda environment and
+    install (or upgrade) seamm_webui into it from PyPI.
+
+    seamm_webui doesn't fit the generic install_packages() flow: it isn't
+    published in the Zenodo-hosted package registry that flow reads from,
+    and unlike everything else there, it's meant to live in its own
+    dedicated environment rather than the shared main one -- the same
+    reasoning already applied to compute-engine environments like
+    mopac-step's `seamm-mopac`, but seamm_webui has no installer.py of its
+    own (a Python daemon, not a plug-in imported by the flowchart engine),
+    so it's handled directly here instead -- the same way `services.py`
+    already special-cases the `dashboard`/`jobserver` daemons rather than
+    going through the generic per-package Installer mechanism.
+
+    The environment itself only needs `python`/`pip` -- seamm_webui's own
+    runtime dependencies (fastapi, uvicorn, ...) are declared in its PyPI
+    package and resolved by pip below, not duplicated here.
+    """
+    name = "seamm-webui"
+
+    if not my.conda.exists(name):
+        print(f"Creating the dedicated '{name}' Conda environment.")
+        spec = f"name: {name}\nchannels:\n  - conda-forge\ndependencies:\n  - python\n  - pip\n"  # noqa: E501
+        with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as fd:
+            fd.write(spec)
+            path = Path(fd.name)
+        try:
+            my.conda.create_environment(path, name=name)
+        finally:
+            path.unlink(missing_ok=True)
+
+    pip = my.conda.path(name) / "bin" / "pip"
+    verb = "Updating" if update else "Installing"
+    print(f"{verb} seamm-webui in the '{name}' environment.")
+    cmd = [str(pip), "install"]
+    if update:
+        cmd.append("--upgrade")
+    cmd.append("seamm-webui")
+    subprocess.run(cmd, check=True)
 
 
 def install_packages(

--- a/seamm_installer/metadata.py
+++ b/seamm_installer/metadata.py
@@ -42,6 +42,11 @@ molssi_plug_ins = (
     "thermal-conductivity-step",
 )
 external_plug_ins = []
+# Packages that install()/services.py handle directly (their own dedicated
+# Conda environment, not the shared main one; no Zenodo package-registry
+# entry) rather than through the generic install_packages()/per-package
+# Installer machinery. See install.py's install_seamm_webui().
+standalone_packages = ("seamm-webui",)
 
 excluded_plug_ins = (
     "chemical-formula",

--- a/seamm_installer/services.py
+++ b/seamm_installer/services.py
@@ -22,7 +22,7 @@ elif system in ("Linux",):
 else:
     raise NotImplementedError(f"SEAMM does not support services on {system} yet.")
 
-known_services = ["dashboard", "jobserver"]
+known_services = ["dashboard", "jobserver", "webui"]
 
 
 def setup(parser):
@@ -56,6 +56,16 @@ def setup(parser):
     tmp_parser.add_argument(
         "--dashboard-name",
         default=f"{host} Development" if my.development else host,
+    )
+    tmp_parser.add_argument(
+        "--webui-host",
+        default="0.0.0.0",
+        help=(
+            "Host for the webui service to bind to (default: %(default)s, "
+            "i.e. reachable from other machines -- seamm_webui then "
+            "requires per-user login and self-signed HTTPS automatically; "
+            "use 127.0.0.1 for local-only, no-login access instead)."
+        ),
     )
     tmp_parser.add_argument(
         "services",
@@ -149,13 +159,31 @@ def create():
                 )
                 continue
         # Proceed to creating the service.
-        exe_path = shutil.which(f"seamm-{service}")
-        if exe_path is None:
-            exe_path = shutil.which(service)
-        if exe_path is None:
-            print(f"Could not find seamm-{service} or {service}. Is it installed?")
-            print()
-            continue
+        if service == "webui":
+            # Lives in its own dedicated Conda environment, not the active
+            # one -- see install.py's install_seamm_webui() -- so it can't
+            # be found with shutil.which() against the current PATH like
+            # dashboard/jobserver, which share the main environment.
+            try:
+                exe_path = str(my.conda.path("seamm-webui") / "bin" / "seamm-webui")
+            except ValueError:
+                exe_path = None
+            if exe_path is None or not Path(exe_path).is_file():
+                print(
+                    "Could not find seamm-webui in the 'seamm-webui' Conda "
+                    "environment. Run 'seamm-installer install seamm-webui' "
+                    "first."
+                )
+                print()
+                continue
+        else:
+            exe_path = shutil.which(f"seamm-{service}")
+            if exe_path is None:
+                exe_path = shutil.which(service)
+            if exe_path is None:
+                print(f"Could not find seamm-{service} or {service}. Is it installed?")
+                print()
+                continue
 
         root = "~/SEAMM_DEV" if my.development else "~/SEAMM"
         stderr_path = Path(f"{my.options.root}/logs/{service}.out").expanduser()
@@ -171,6 +199,19 @@ def create():
                 my.options.port,
                 "--dashboard-name",
                 my.options.dashboard_name,
+                stderr_path=str(stderr_path),
+                stdout_path=str(stdout_path),
+            )
+        elif service == "webui":
+            mgr.create(
+                service_name,
+                exe_path,
+                "--root",
+                root,
+                "--port",
+                my.options.port,
+                "--host",
+                my.options.webui_host,
                 stderr_path=str(stderr_path),
                 stdout_path=str(stdout_path),
             )


### PR DESCRIPTION
* `seamm-installer install seamm-webui` creates a dedicated `seamm-webui` Conda environment (it shares little with the rest of the SEAMM stack) and installs `seamm_webui` from PyPI into it.
* `seamm-installer services create webui` (alongside the existing `dashboard`/`jobserver` services) sets up and starts it as a persistent systemd/launchd daemon, with a new `--webui-host` option.