### PR TITLE
Bugfix: services create ignored a custom --root

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 =======
 History
 =======
+2026.8.10.1 -- Bugfix: services create ignored a custom --root
+    * ``seamm-installer services create`` always hardcoded the ``--root``
+      baked into a new service's daemon to ``~/SEAMM``/``~/SEAMM_DEV``
+      (based on development mode), silently ignoring an explicit ``--root``
+      passed on the command line. Found while deploying/testing ``webui``
+      against a scratch root on MolSSI10. Now uses the actual resolved
+      ``--root`` value.
+
 2026.8.10 -- Install and daemonize seamm_webui
     * ``seamm-installer install seamm-webui`` creates a dedicated ``seamm-webui``
       Conda environment (it shares little with the rest of the SEAMM stack) and

--- a/seamm_installer/services.py
+++ b/seamm_installer/services.py
@@ -185,7 +185,11 @@ def create():
                 print()
                 continue
 
-        root = "~/SEAMM_DEV" if my.development else "~/SEAMM"
+        # my.options.root already defaults to ~/SEAMM_DEV or ~/SEAMM based on
+        # development mode (see __main__.py) but also respects an explicit
+        # --root override -- use it directly rather than re-deriving a
+        # hardcoded value here, which silently ignored --root entirely.
+        root = my.options.root
         stderr_path = Path(f"{my.options.root}/logs/{service}.out").expanduser()
         stdout_path = Path(f"{my.options.root}/logs/{service}.out").expanduser()
 


### PR DESCRIPTION
* `seamm-installer services create` always hardcoded the `--root` baked into a new service's daemon to `~/SEAMM`/`~/SEAMM_DEV` (based on development mode), silently ignoring an explicit `--root` passed on the command line. Found while deploying/testing `webui` against a scratch root on MolSSI10. Now uses the actual resolved `--root` value.